### PR TITLE
Implementation of Scoped Storage Permissions in Android 11 and above in JAVA.

### DIFF
--- a/Android/ScopedStorage and Permissions in Android 11/Code/AndroidManifest.xml
+++ b/Android/ScopedStorage and Permissions in Android 11/Code/AndroidManifest.xml
@@ -1,0 +1,3 @@
+<uses-permission android:name="android.permission.MANAGE_EXTERNAL_STORAGE"/>
+
+//Instead of READ_EXTERNAL_STORAGE and WRITE_EXTERNAL_STORAGE permissions, we include MANAGE_EXTERNAL_STORAGE permissions.

--- a/Android/ScopedStorage and Permissions in Android 11/Code/MainActivity.java
+++ b/Android/ScopedStorage and Permissions in Android 11/Code/MainActivity.java
@@ -1,0 +1,70 @@
+private static final int PERMISSION_REQUEST_CODE = 0;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        ThemeUtils.getInstance().setThemeApp(this);
+        super.onCreate(savedInstanceState);
+
+        setContentView(R.layout.activity_main);
+      
+      if (!isPermissionGranted()) {
+            showPermissionDialog();
+        }
+    }
+
+
+
+
+private void showPermissionDialog() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            try {
+                Intent intent = new Intent(Settings.ACTION_MANAGE_ALL_FILES_ACCESS_PERMISSION);
+                intent.addCategory("android.intent.category.DEFAULT");
+                intent.setData(Uri.parse(String.format("package:%s",
+                        new Object[]{getApplicationContext().getPackageName()})));
+                startActivityForResult(intent, 100);
+            } catch (Exception e) {
+                Intent intent = new Intent(Settings.ACTION_MANAGE_ALL_FILES_ACCESS_PERMISSION);
+                startActivityForResult(intent, 100);
+            }
+        } else {
+            ActivityCompat.requestPermissions(MainActivity.this,
+                    new String[]{READ_EXTERNAL_STORAGE}, 101);
+        }
+    }
+
+    private boolean isPermissionGranted() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            return Environment.isExternalStorageManager();
+        } else {
+            int readExternalStoragePermission = ContextCompat.checkSelfPermission(this,
+                    Manifest.permission.READ_EXTERNAL_STORAGE);
+            return readExternalStoragePermission == PackageManager.PERMISSION_GRANTED;
+        }
+    }
+
+    @Override
+    protected void onActivityResult(int requestCode, int resultCode, @Nullable Intent data) {
+        super.onActivityResult(requestCode, resultCode, data);
+        if (resultCode == RESULT_OK) {
+            if (requestCode == 100) {
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+                    if (Environment.isExternalStorageManager()) {
+                        Toast.makeText(this, "Permission Granted in android 11", Toast.LENGTH_SHORT).show();
+                    }
+                }
+            }
+        }
+    }
+
+    @Override
+    public void onRequestPermissionsResult(int requestCode, @NonNull String[] permissions,
+                                           @NonNull int[] grantResults) {
+        super.onRequestPermissionsResult(requestCode, permissions, grantResults);
+        if (requestCode == 101 && grantResults.length > 0) {
+            boolean readExternalStorage = grantResults[0] == PackageManager.PERMISSION_GRANTED;
+            if (readExternalStorage) {
+                Toast.makeText(this, "Read Permission is granted in android 10 or below", Toast.LENGTH_SHORT).show();
+            }
+        }
+    }

--- a/Android/ScopedStorage and Permissions in Android 11/README.md
+++ b/Android/ScopedStorage and Permissions in Android 11/README.md
@@ -1,0 +1,16 @@
+**Introduction to Scoped Storage:**
+```
+Apps that run on Android 11 but target Android 10 (API level 29) can still request the requestLegacyExternalStorage attribute. 
+This flag allows apps to temporarily opt out of the changes associated with scoped storage, such as granting access to different directories and different types of media files.
+After you update your app to target Android 11, the system ignores the requestLegacyExternalStorage flag.
+```
+
+**Managing Scoped Storage:**
+
+
+```
+Starting in Android 11, apps that use the scoped storage model can access only their own app-specific cache files.
+
+1. Check for free space by invoking the ACTION_MANAGE_STORAGE intent action.
+2. If there isn't enough free space on the device, prompt the user to give your app consent to clear all caches. To do so, invoke the ACTION_CLEAR_APP_CACHE intent action.
+```

--- a/Android/ScopedStorage and Permissions in Android 11/README.md
+++ b/Android/ScopedStorage and Permissions in Android 11/README.md
@@ -1,7 +1,8 @@
 **Introduction to Scoped Storage:**
 ```
 Apps that run on Android 11 but target Android 10 (API level 29) can still request the requestLegacyExternalStorage attribute. 
-This flag allows apps to temporarily opt out of the changes associated with scoped storage, such as granting access to different directories and different types of media files.
+This flag allows apps to temporarily opt out of the changes associated with scoped storage,
+such as granting access to different directories and different types of media files.
 After you update your app to target Android 11, the system ignores the requestLegacyExternalStorage flag.
 ```
 
@@ -12,5 +13,6 @@ After you update your app to target Android 11, the system ignores the requestLe
 Starting in Android 11, apps that use the scoped storage model can access only their own app-specific cache files.
 
 1. Check for free space by invoking the ACTION_MANAGE_STORAGE intent action.
-2. If there isn't enough free space on the device, prompt the user to give your app consent to clear all caches. To do so, invoke the ACTION_CLEAR_APP_CACHE intent action.
+2. If there isn't enough free space on the device, prompt the user to give your app consent to clear all caches. 
+To do so, invoke the ACTION_CLEAR_APP_CACHE intent action.
 ```


### PR DESCRIPTION
## What type of PR is this? (check all applicable)


- [ ] 🚀 Added Name
- [ ] ✨ Feature
- [ ] 🌟 stared the repo
- [ ] 🐛 Grammatical Error
- [ ] 📝 Documentation Update
- [ ] 🚩 Other

## Description

This commit shows how to use the new Jetpack Component Feature Scoped Storage in Android 11. The main java code is in MainActivity.java and some useful permissions are present in AndroidManifest.xml

## Add Link of GitHub Profile

https://github.com/debz-g
